### PR TITLE
Fixed the duplicated recent pages bug on dashboard

### DIFF
--- a/client/src/pages/auth/dashboard/Dashboard.jsx
+++ b/client/src/pages/auth/dashboard/Dashboard.jsx
@@ -182,6 +182,7 @@ export default function DashboardPage({ user, setAuthentication }) {
       setRecentPages(tempRecentPages.slice(0, 4));
       setTimeout(() => {
         setRecentPagesLoaded(true);
+        setTempRecentPages([]);
         setProjectsFetched(false);
         setTasksFetched(false);
       }, 250);

--- a/todo.TODO
+++ b/todo.TODO
@@ -8,4 +8,4 @@ Todos:
 Features:
 
 Bugs: 
-  []  @medium There is a bug in the dashboard page that creates some duplicates in the recent pages if a user creates a new project or task.
+  [+]  @medium There is a bug in the dashboard page that creates some duplicates in the recent pages if a user creates a new project or task.


### PR DESCRIPTION
✅ Fixed the bug that was causing the recent pages to be duplicated whenever a user creates a new task or project from the quick actions on the dashboard page.



