### PR TITLE
Fixed some bugs related to sorting projects and tasks

### DIFF
--- a/client/src/pages/auth/components/SectionHeader.jsx
+++ b/client/src/pages/auth/components/SectionHeader.jsx
@@ -155,17 +155,21 @@ export default function SectionHeader(props) {
               <HiViewGrid />
             </IconContext.Provider>
           </button>
-          <button
-            className={
-              "kanban-view" +
-              (props.selectedView === "kanban" ? " selected" : "")
-            }
-            onClick={() => setKanbanView()}
-          >
-            <IconContext.Provider value={{ style: { fontSize: "28px" } }}>
-              <LuKanban />
-            </IconContext.Provider>
-          </button>
+          {props.page === "projects" ? (
+            <button
+              className={
+                "kanban-view" +
+                (props.selectedView === "kanban" ? " selected" : "")
+              }
+              onClick={() => setKanbanView()}
+            >
+              <IconContext.Provider value={{ style: { fontSize: "28px" } }}>
+                <LuKanban />
+              </IconContext.Provider>
+            </button>
+          ) : (
+            ""
+          )}
         </div>
         <button
           className={

--- a/client/src/pages/auth/projects/Projects.jsx
+++ b/client/src/pages/auth/projects/Projects.jsx
@@ -93,14 +93,7 @@ export default function ProjectsPage({ user, setAuthentication }) {
       setTokenValidated
     );
     // setProjectsFetched(true);
-  }, [
-    newProjectCreated,
-    projectDeleted,
-    projectUpdated,
-    // filterCleared,
-    loadProjects,
-    // sortCleared,
-  ]);
+  }, [newProjectCreated, projectDeleted, projectUpdated, loadProjects]);
 
   useEffect(() => {
     if (newAccessToken.counter > 0) {
@@ -122,26 +115,24 @@ export default function ProjectsPage({ user, setAuthentication }) {
   }, [newAccessToken]);
 
   useEffect(() => {
-    filterProjectsUtil(
-      filter,
-      search,
-      applySort === 0 ? projects : sortedList,
-      setFilteredList
-    );
-  }, [search, applyFilters]);
+    if (search !== "" || applyFilters > 0 || projects || applySort === 0) {
+      filterProjectsUtil(
+        filter,
+        search,
+        applySort === 0 ? projects : sortedList,
+        setFilteredList
+      );
+    }
+  }, [search, applyFilters, projects, applySort]);
 
   useEffect(() => {
-    if (applySort > 0) {
-      setSortedList((currentList) => {
-        return sortProjectsUtil(currentList, projects, sort);
-      });
-      if (applyFilters > 0) {
-        setFilteredList((currentList) => {
-          return sortProjectsUtil(currentList, projects, sort);
-        });
-      }
+    if (applySort > 0 || projects) {
+      setSortedList(sortProjectsUtil(projects, sort));
     }
-  }, [applySort]);
+    if (applySort > 0 && (applyFilters > 0 || search !== "")) {
+      setFilteredList(sortProjectsUtil(filteredList, sort));
+    }
+  }, [applySort, projects]);
 
   useEffect(() => {
     console.log(projects);
@@ -604,6 +595,7 @@ export default function ProjectsPage({ user, setAuthentication }) {
                         deleteProject={deleteProject}
                         hoverOverProject={hoverOverProject}
                         hoverOverProjectEnd={hoverOverProjectEnd}
+                        updatedStatus={updatedStatus}
                       />
                     );
                   }

--- a/client/src/pages/auth/projects/utils/sortProjectsUtil.js
+++ b/client/src/pages/auth/projects/utils/sortProjectsUtil.js
@@ -1,6 +1,8 @@
-export default function sortProjectsUtil(unsoredProjectsList, projects, sort) {
-  let unsortedList =
-    unsoredProjectsList.length === 0 ? [...projects] : [...unsoredProjectsList];
+export default function sortProjectsUtil(projects, sort) {
+  let unsortedList = [...projects];
+  unsortedList.sort((a, b) => {
+    return new Date(b.updated_on).getTime() - new Date(a.updated_on).getTime();
+  });
   if (Number(sort.sort_by) !== 0) {
     if (sort.sort_by === "1") {
       unsortedList.sort((a, b) => {

--- a/client/src/pages/auth/tasks/Tasks.jsx
+++ b/client/src/pages/auth/tasks/Tasks.jsx
@@ -115,26 +115,24 @@ export default function TasksPage({ user, setAuthentication }) {
   }, [newAccessToken]);
 
   useEffect(() => {
-    filterTasksUtil(
-      filter,
-      search,
-      applySort === 0 ? tasks : sortedList,
-      setFilteredList
-    );
-  }, [search, applyFilters]);
+    if (search !== "" || applyFilters > 0 || tasks || applySort === 0) {
+      filterTasksUtil(
+        filter,
+        search,
+        applySort === 0 ? tasks : sortedList,
+        setFilteredList
+      );
+    }
+  }, [search, applyFilters, tasks, applySort]);
 
   useEffect(() => {
-    if (applySort > 0) {
-      setSortedList((currentList) => {
-        return sortTasksUtil(currentList, tasks, sort);
-      });
-      if (applyFilters > 0) {
-        setFilteredList((currentList) => {
-          return sortTasksUtil(currentList, tasks, sort);
-        });
-      }
+    if (applySort > 0 || tasks) {
+      setSortedList(sortTasksUtil(tasks, sort));
     }
-  }, [applySort]);
+    if (applySort > 0 && (applyFilters > 0 || search !== "")) {
+      setFilteredList(sortTasksUtil(filteredList, sort));
+    }
+  }, [applySort, tasks]);
 
   useEffect(() => {
     if (Object.keys(newTask).length > 0 && create > 0) {

--- a/client/src/pages/auth/tasks/utils/sortTasksUtil.js
+++ b/client/src/pages/auth/tasks/utils/sortTasksUtil.js
@@ -1,6 +1,5 @@
-export default function sortTasksUtil(unsortedTasksList, tasks, sort) {
-  let unsortedList =
-    unsortedTasksList.length === 0 ? [...tasks] : [...unsortedTasksList];
+export default function sortTasksUtil(tasks, sort) {
+  let unsortedList = [...tasks];
   if (Number(sort.sort_by) === 1) {
     unsortedList.sort((a, b) => {
       if (sort.type === 1) {

--- a/todo.TODO
+++ b/todo.TODO
@@ -17,6 +17,7 @@ Features:
 Bugs: 
   [+]  @medium There is a bug in the dashboard page that creates some duplicates in the recent pages if a user creates a new project or task.
   [+]  @medium Sorting projects and tasks doesn't work in some cases with the filter applied.
-  []  @low When creating or updating a project or a task while a sort is applied, the sort then gets reseted to the default one.
-  []  @low When trying to sort projects or tasks while they have been filtered using the search feature, it doesn't get applied until you update the search keyword.
-  []  @medium Sorting projects or tasks while the list is already filtered by a search keyword doesn't work.
+  [+]  @low When creating a new project or task while a sort or/and a filter is applied, the new record doesn't show on the list until you refresh the page.
+  [+]  @low When updating a project or task while a sort or/and a filter is applied the update doesn't show on the list until you refresh the page.
+  [+]  @low When deleting a project or task while a sort or/and a filter is applied the animation of the project being deleted stays on the list until you refresh the page.
+  [+]  @low When trying to sort projects or tasks while they have been filtered using the search feature, it doesn't get applied until you update the search keyword.


### PR DESCRIPTION
✅ Fixed the following bugs

1. 🐞 When a user creates a new project or task while a sort is applied to the list, the new record doesn't show up until the page is refreshed.
2. 🐞 When a user updates a project or task while a sort is applied to the list, both the record and the list are not updated until the page is refreshed.
3. 🐞 When a user deletes a project or task while a sort is applied to the list, if it's a project then the project is shown as being deleted and stays like that until the page is refreshed, or if it's a task then the task doesn't disappear until the page is refreshed.
4. 🐞 When a user tries to sort a list while it's already filtered with a keyword, it doesn't work.