### PR TITLE
Tasks Kanban switch button

### DIFF
--- a/client/src/pages/auth/components/SectionHeader.jsx
+++ b/client/src/pages/auth/components/SectionHeader.jsx
@@ -51,7 +51,8 @@ export default function SectionHeader(props) {
     }
   };
 
-  const openKanbanSelect = () => {
+  const openKanbanSelect = (event) => {
+    event.preventDefault();
     handleKanbanSelect(props.selectedView);
   };
 
@@ -227,7 +228,7 @@ export default function SectionHeader(props) {
                 (props.selectedView === "kanban" ? " selected" : "")
               }
               onClick={() => setKanbanView()}
-              onDoubleClick={() => openKanbanSelect()}
+              onContextMenu={(e) => openKanbanSelect(e)}
               onMouseEnter={() => showToolTip()}
               onMouseLeave={() => hideToolTip()}
             >
@@ -238,7 +239,7 @@ export default function SectionHeader(props) {
                     (toolTipVisible ? " visible" : "")
                   }
                 >
-                  Double click
+                  Right click
                 </div>
               ) : (
                 ""

--- a/client/src/pages/auth/projects/modern/Projects.jsx
+++ b/client/src/pages/auth/projects/modern/Projects.jsx
@@ -555,8 +555,7 @@ export default function ProjectsPageModern({
                   </label>
                   <select
                     name="sort-by"
-                    className="sort-by"
-                    className="poppins-regular"
+                    className="sort-by poppins-regular"
                     value={
                       Object.keys(sortBy).indexOf("by") !== -1
                         ? sortBy.by


### PR DESCRIPTION
✅ Updated the kanban view switch on the tasks page (Classic UI) to open with a right click instead of a double click.

